### PR TITLE
UpdateSkeleton - Add backend block and make the right module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# terraform-bootstrap
-Init code for terraform backend and authentication
+# Terraform Bootstrap
+The main terraform repository for managing other terraform repos
+- Provision backends (S3, DynamoDB) 
+- Setup OIDC and roles to assume
+
+> **Notice:** <br> This terraform repo also requires remote backend setup and authentication configs, you will have to either create them manually from the cloud console or use a script to provision them.
+

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ terraform {
       version = "~> 5.1"
     }
   }
+  
+  # Backend Skeleton
+  backend "s3" {}
 }
 
 provider "aws" {

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = "~> 5.1"
     }
   }
-  
+
   # Backend Skeleton
   backend "s3" {}
 }
@@ -14,33 +14,34 @@ provider "aws" {
   region = var.location
 }
 
-# Terraform state
+# Terraform states
 module "terraform_state" {
   for_each    = toset(var.repos)
   source      = "./modules/bucket"
-  bucket_name = "${var.org_abbr}-${each.key}-terraform-state"
+  bucket_name = "${var.org_abbr}-${each.key}-tfstate"
 }
 
-# Terraform LockID
+# Terraform LockIDs
 module "terraform_locks" {
   for_each   = toset(var.repos)
   source     = "./modules/db"
-  table_name = "${var.org_abbr}-${each.key}-terraform-lock"
+  table_name = "${var.org_abbr}-${each.key}-tflock"
 }
 
-# Fetch GitHub OIDC Thumbprint
-data "tls_certificate" "github" {
-  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+# OIDC Provider
+module "oidc_provider" {
+  source              = "./modules/oidc"
+  provider_thumbprint = var.oidc_provider_thumbprint
+  audience_url        = var.oidc_audience_url
 }
 
-# OIDC Assume Roles
+# Assume Roles with OIDC
 module "terraform_roles" {
-  for_each    = toset(var.repos)
-  source      = "./modules/oidc"
-  org_abbr    = var.org_abbr
-  orgnisation = var.orgnisation
-  repo_name   = each.key
-
-  # Accept manual input for thumbprint or else try to use fetched cert
-  provider_thumbprint = coalesce(var.oidc_provider_thumbprint, data.tls_certificate.github.certificates[0].sha1_fingerprint)
+  for_each     = toset(var.repos)
+  source       = "./modules/role"
+  oidc         = module.oidc_provider.github
+  audience_url = var.oidc_audience_url
+  org_abbr     = var.org_abbr
+  orgnisation  = var.orgnisation
+  repo_name    = each.key
 }

--- a/modules/oidc/main.tf
+++ b/modules/oidc/main.tf
@@ -1,54 +1,11 @@
-locals {
-  # Full Repository name including Orgnisation name
-  full_repo_name = "${var.orgnisation}/${var.repo_name}"
-
-  # Get rid of https://
-  provider_domain = split("/", var.provider_url)[2]
+# Fetch GitHub OIDC Thumbprint
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
 }
 
-resource "aws_iam_openid_connect_provider" "oidc" {
+# Add github OIDC
+resource "aws_iam_openid_connect_provider" "github" {
   url             = var.provider_url
   client_id_list  = [var.audience_url]
-  thumbprint_list = [var.provider_thumbprint]
-}
-
-# Example policy
-data "aws_iam_policy" "fetched_policy" {
-  name = "IAMFullAccess"
-}
-
-# Describe the trust entity
-data "aws_iam_policy_document" "assume_policy" {
-  statement {
-    effect = "Allow"
-    principals {
-      type        = "Federated"
-      identifiers = [aws_iam_openid_connect_provider.oidc.arn]
-    }
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    condition {
-      test     = "StringEquals"
-      variable = "${local.provider_domain}:aud"
-
-      values = [var.audience_url]
-    }
-    condition {
-      test     = "StringLike"
-      variable = "${local.provider_domain}:sub"
-
-      values = ["repo:${local.full_repo_name}:*"]
-    }
-  }
-}
-
-# Config trust entity authenticate conditions
-resource "aws_iam_role" "remote_sts_role" {
-  name               = "oidc-${var.org_abbr}-${var.repo_name}"
-  assume_role_policy = data.aws_iam_policy_document.assume_policy.json
-}
-
-# Assign permission policy to role
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
-  role_name   = aws_iam_role.remote_sts_role.name
-  policy_arns = [data.aws_iam_policy.fetched_policy.arn]
+  thumbprint_list = [coalesce(var.provider_thumbprint, data.tls_certificate.github.certificates[0].sha1_fingerprint)]
 }

--- a/modules/oidc/outputs.tf
+++ b/modules/oidc/outputs.tf
@@ -1,0 +1,3 @@
+output "github" {
+  value = aws_iam_openid_connect_provider.github
+}

--- a/modules/oidc/variables.tf
+++ b/modules/oidc/variables.tf
@@ -8,24 +8,12 @@ variable "audience_url" {
   default = "sts.amazonaws.com"
 }
 
-variable "org_abbr" {
-  type = string
-}
-
-variable "orgnisation" {
-  type = string
-}
-
-variable "repo_name" {
-  type = string
-}
-
 # This also allow manual input for thumbprint, in case the data block cannot fetch the tls cert
 variable "provider_thumbprint" {
   type = string
 
-  validation {
-    condition     = length(var.provider_thumbprint) == 40
-    error_message = "The length of oidc provider thumbprint must be exact 40"
-  }
+  # validation {
+  #   condition     = length(var.provider_thumbprint) == 40
+  #   error_message = "The length of oidc provider thumbprint must be exact 40"
+  # }
 }

--- a/modules/role/main.tf
+++ b/modules/role/main.tf
@@ -1,0 +1,48 @@
+locals {
+  # Full Repository name including Orgnisation name
+  full_repo_name = "${var.orgnisation}/${var.repo_name}"
+
+  # AWS oidc audience url
+  audience_url = var.audience_url
+}
+
+# Example policy
+data "aws_iam_policy" "fetched_policy" {
+  name = "IAMFullAccess"
+}
+
+# Describe the trust entity
+data "aws_iam_policy_document" "assume_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc.arn]
+    }
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    condition {
+      test     = "StringEquals"
+      variable = "${var.oidc.url}:aud"
+
+      values = [local.audience_url]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "${var.oidc.url}:sub"
+
+      values = ["repo:${local.full_repo_name}:*"]
+    }
+  }
+}
+
+# Config trust entity authenticate conditions
+resource "aws_iam_role" "remote_sts_role" {
+  name               = "oidc-${var.org_abbr}-${var.repo_name}"
+  assume_role_policy = data.aws_iam_policy_document.assume_policy.json
+}
+
+# Assign permission policy to role
+resource "aws_iam_role_policy_attachments_exclusive" "example" {
+  role_name   = aws_iam_role.remote_sts_role.name
+  policy_arns = [data.aws_iam_policy.fetched_policy.arn]
+}

--- a/modules/role/variables.tf
+++ b/modules/role/variables.tf
@@ -1,0 +1,23 @@
+variable "oidc" {
+  type = object({
+    arn = string
+    url = string
+  })
+}
+
+variable "audience_url" {
+  type    = string
+  default = "sts.amazonaws.com"
+}
+
+variable "org_abbr" {
+  type = string
+}
+
+variable "orgnisation" {
+  type = string
+}
+
+variable "repo_name" {
+  type = string
+}


### PR DESCRIPTION
# Summary
This is the initialisation of terraform bootstrap. After few refinement, this bootstrap will take charge of state file and permission management for all the other IaC repos within this project.

## Details
- **Add backend block**
  - A blank backend block for security concerns
  - Accept config injection on `terraform init`
- **Separate the role and oidc module**
  - For better maintenance
  - Avoid duplication of oidc provider

## Testing
I have tested the terraform code on my own aws account both with and without the backend injection, they worked fine.

**S3 backend** ✔
- Inline command injection ✔
- Manual input within cli ✔

**Use local** ✔
**Yet to be tested in Workflow** ❓
## Related
#2 - Terraform backend config should be injected during the preparation stage of the CD workflow