### PR TITLE
Init CI workflow for Terraform Bootstrap

### DIFF
--- a/.github/actions/setup_with_key/action.yml
+++ b/.github/actions/setup_with_key/action.yml
@@ -1,0 +1,55 @@
+name: Terraform Setup and Plan
+inputs:
+  terraform_version:
+    description: 'Terraform Version'
+    required: true
+  terraform_dir:
+    description: 'Working directory of terraform'
+    required: true
+  aws_region:
+    description: 'AWS Resource Region'
+    required: true
+  aws_access_key:
+    description: 'AWS Access Key ID'
+    required: true
+  aws_secret_key:
+    description: 'AWS Secret Access Key'
+    required: true
+  aws_tfstate_bucket:
+    description: 'AWS Backend Bucket'
+    required: true
+  aws_tfstate_key:
+    description: 'AWS Terraform State File Key'
+    required: true
+  aws_tflock_table:
+    description: 'AWS Terraform Locking table'
+    required: true
+  
+runs:
+  using: 'composite'
+  steps:
+    - id: tf_setup
+      name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ inputs.terraforom_version }}
+    
+    - id: aws_auth
+      name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-region: ${{ inputs.aws_region }}
+        aws-access-key-id: ${{ inputs.aws_access_key }}
+        aws-secret-access-key: ${{ inputs.aws_secret_key }}
+    
+    - id: tf_init
+      name: Init Terraform
+      working-directory: ${{ inputs.terraform_dir }}
+      shell: bash
+      run: |
+        terraform init \
+          -backend-config="bucket=${{ inputs.aws_tfstate_bucket }}" \
+          -backend-config="key=${{ inputs.aws_tfstate_key }}" \
+          -backend-config="region=${{ inputs.aws_region }}" \
+          -backend-config="encrypt=true" \
+          -backend-config="dynamodb_table=${{ inputs.aws_tflock_table }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -3,10 +3,9 @@ on:
   pull_request:
 
 permissions:
-  # This is required for requesting the JWT (OIDC)
-  id-token: write 
-  # This is required for checkout code
+  id-token: write # This is required for requesting the JWT (OIDC)
   contents: read
+  pull-requests: write
 
 jobs:
   terraform_plan:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -41,7 +41,7 @@ jobs:
 
       - id: tf_plan
         name: Terraform Plan
-        run: terrafrom plan -out .planfile
+        run: terraform plan -out .planfile
 
       - id: post_comment
         name: Post Terraform Plan to PR

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -14,8 +14,10 @@ jobs:
     # Specify trigger condition
     if: github.event.pull_request.state != 'approved'
     env:
-      # These are for testing
       terraform_version: "1.1.7"
+      # Non-Empty thumbprint will stop terraform from fetching it on the fly
+      github_oidc_provider_thumbprint: ""
+      # These are for testing purpose
       aws_region: "us-west-2"
       aws_tfstate_bucket: "inff-5u91r-terraform-bootstrap-tfstate"
       aws_tfstate_key: "state/terraform-state"
@@ -42,6 +44,8 @@ jobs:
       - id: tf_plan
         name: Terraform Plan
         run: terraform plan -out .planfile
+        env:
+          TF_VAR_oidc_provider_thumbprint: ${{ env.github_oidc_provider_thumbprint }}
 
       - id: post_comment
         name: Post Terraform Plan to PR

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,53 @@
+name: Terraform Plan
+on:
+  pull_request:
+
+permissions:
+  # This is required for requesting the JWT (OIDC)
+  id-token: write 
+  # This is required for checkout code
+  contents: read
+
+jobs:
+  terraform_plan:
+    runs-on: ubuntu-22.04
+    # Specify trigger condition
+    if: github.event.pull_request.state != 'approved'
+    env:
+      # These are for testing
+      terraform_version: "1.1.7"
+      aws_region: "us-west-2"
+      aws_tfstate_bucket: "inff-5u91r-terraform-bootstrap-tfstate"
+      aws_tfstate_key: "state/terraform-state"
+      aws_tflock_table: "inff-5u91r-terraform-bootstrap-tflock"
+    
+    steps:
+      - id: checkout_latest
+        name: Checkout latest
+        uses: actions/checkout@v4
+
+      - id: tf_prep
+        name: Terraform setup using Access Key
+        uses: ./.github/actions/setup_with_key
+        with:
+          terraform_dir: "./"
+          terraform_version: ${{ env.terraform_version }}
+          aws_region: ${{ env.aws_region }}
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
+          aws_tfstate_bucket: ${{ env.aws_tfstate_bucket }}
+          aws_tfstate_key: ${{ env.aws_tfstate_key }}
+          aws_tflock_table: ${{ env.aws_tflock_table }}
+
+      - id: tf_plan
+        name: Terraform Plan
+        run: terrafrom plan -out .planfile
+
+      - id: post_comment
+        name: Post Terraform Plan to PR
+        uses: borchero/terraform-plan-comment@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          planfile: .planfile
+      
+      # Upload planfile to s3 for future apply

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# For local testing
+.env
+.secrets


### PR DESCRIPTION
# Summary
This is the initialisation of CI workflow for terraform bootstrap. Current workflow only contain terraform setup and plan. We need further discussion about the deploy strategy(`terraform apply`).
## Details
- **A composite action `.github/actions/setup_with_key/action.yml` for terraform setup and init**
  - Use Hashicorp official action [setup-terraform](https://github.com/hashicorp/setup-terraform)
  - Use AWS offical action [configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)
    - Since this is the bootstrap IaC, it takes care of all the roles and oidc resources, the AWS access key is used for authentication, we are still looking for better solutions.
  - Run `terraform init` with backend config injection
- **A workflow `.github/workflows/terraform-plan.yml` for terraform plan and print result to PR**
  - Use checkout to fetch latest code
  - Use the composite action `setup_with_key` mentioned above
  - Run `terraform plan`
  - Use community action [terraform-plan-comment](https://github.com/borchero/terraform-plan-comment)
    - This will read and format the plan output and comment it to the PR

## Testing
I have tested the pipeline locally using [act](https://nektosact.com/), with secrets managed in local files.

- **Terraform init** ✔
- **AWS authentication** ✔
- **Terrafrom plan** ✔
- **Post plan to PR** ✔
  - Cannot be tested locally
  - Seems to work fine, check bot comment below