### PR TITLE
Feature/7 attach basic permission to OIDC roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,14 +22,15 @@ module "oidc_provider" {
 }
 
 # Assume Roles with OIDC
-module "github_roles" {
-  for_each     = toset(var.repos)
-  source       = "./modules/role"
-  oidc         = module.oidc_provider.github
-  audience_url = var.oidc_audience_url
-  org_abbr     = var.org_abbr
-  orgnisation  = var.orgnisation
-  repo_name    = each.key
+module "repo_roles" {
+  for_each      = toset(var.repos)
+  source        = "./modules/role"
+  oidc          = module.oidc_provider.github
+  role_policies = var.repo_permission[each.key]
+  audience_url  = var.oidc_audience_url
+  org_abbr      = var.org_abbr
+  orgnisation   = var.orgnisation
+  repo_name     = each.key
 }
 
 # Workflow Artifact
@@ -37,7 +38,7 @@ module "workflow_artifact" {
   for_each       = toset(var.repos)
   source         = "./modules/bucket"
   bucket_name    = "${var.org_abbr}-${each.key}-workflow-artifact"
-  principal_role = module.github_roles[each.key].role
+  principal_role = module.repo_roles[each.key].role_obj
 }
 
 # Terraform states
@@ -45,7 +46,7 @@ module "terraform_state" {
   for_each       = toset(var.repos)
   source         = "./modules/bucket"
   bucket_name    = "${var.org_abbr}-${each.key}-tfstate"
-  principal_role = module.github_roles[each.key].role
+  principal_role = module.repo_roles[each.key].role_obj
 }
 
 # Terraform LockIDs
@@ -53,5 +54,5 @@ module "terraform_locks" {
   for_each       = toset(var.repos)
   source         = "./modules/db"
   table_name     = "${var.org_abbr}-${each.key}-tflock"
-  principal_role = module.github_roles[each.key].role
+  principal_role = module.repo_roles[each.key].role_obj
 }

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,8 @@ module "terraform_state" {
 
 # Terraform LockIDs
 module "terraform_locks" {
-  for_each   = toset(var.repos)
-  source     = "./modules/db"
-  table_name = "${var.org_abbr}-${each.key}-tflock"
+  for_each       = toset(var.repos)
+  source         = "./modules/db"
+  table_name     = "${var.org_abbr}-${each.key}-tflock"
+  principal_role = module.github_roles[each.key].role
 }

--- a/main.tf
+++ b/main.tf
@@ -14,27 +14,6 @@ provider "aws" {
   region = var.location
 }
 
-# Workflow Artifact
-module "workflow_artifact" {
-  for_each = toset(var.repos)
-  source = "./modules/bucket"
-  bucket_name = "${var.org_abbr}-${each.key}-workflow-artifact"
-}
-
-# Terraform states
-module "terraform_state" {
-  for_each    = toset(var.repos)
-  source      = "./modules/bucket"
-  bucket_name = "${var.org_abbr}-${each.key}-tfstate"
-}
-
-# Terraform LockIDs
-module "terraform_locks" {
-  for_each   = toset(var.repos)
-  source     = "./modules/db"
-  table_name = "${var.org_abbr}-${each.key}-tflock"
-}
-
 # OIDC Provider
 module "oidc_provider" {
   source              = "./modules/oidc"
@@ -43,7 +22,7 @@ module "oidc_provider" {
 }
 
 # Assume Roles with OIDC
-module "terraform_roles" {
+module "github_roles" {
   for_each     = toset(var.repos)
   source       = "./modules/role"
   oidc         = module.oidc_provider.github
@@ -51,4 +30,27 @@ module "terraform_roles" {
   org_abbr     = var.org_abbr
   orgnisation  = var.orgnisation
   repo_name    = each.key
+}
+
+# Workflow Artifact
+module "workflow_artifact" {
+  for_each = toset(var.repos)
+  source = "./modules/bucket"
+  bucket_name = "${var.org_abbr}-${each.key}-workflow-artifact"
+  principal_role = module.github_roles[each.key].role
+}
+
+# Terraform states
+module "terraform_state" {
+  for_each    = toset(var.repos)
+  source      = "./modules/bucket"
+  bucket_name = "${var.org_abbr}-${each.key}-tfstate"
+  principal_role = module.github_roles[each.key].role
+}
+
+# Terraform LockIDs
+module "terraform_locks" {
+  for_each   = toset(var.repos)
+  source     = "./modules/db"
+  table_name = "${var.org_abbr}-${each.key}-tflock"
 }

--- a/main.tf
+++ b/main.tf
@@ -34,17 +34,17 @@ module "github_roles" {
 
 # Workflow Artifact
 module "workflow_artifact" {
-  for_each = toset(var.repos)
-  source = "./modules/bucket"
-  bucket_name = "${var.org_abbr}-${each.key}-workflow-artifact"
+  for_each       = toset(var.repos)
+  source         = "./modules/bucket"
+  bucket_name    = "${var.org_abbr}-${each.key}-workflow-artifact"
   principal_role = module.github_roles[each.key].role
 }
 
 # Terraform states
 module "terraform_state" {
-  for_each    = toset(var.repos)
-  source      = "./modules/bucket"
-  bucket_name = "${var.org_abbr}-${each.key}-tfstate"
+  for_each       = toset(var.repos)
+  source         = "./modules/bucket"
+  bucket_name    = "${var.org_abbr}-${each.key}-tfstate"
   principal_role = module.github_roles[each.key].role
 }
 

--- a/modules/bucket/main.tf
+++ b/modules/bucket/main.tf
@@ -32,3 +32,24 @@ resource "aws_s3_bucket_public_access_block" "bkt" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+data "aws_iam_policy_document" "bkt_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [var.principal_role.arn]
+    }
+    actions = [
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = [aws_s3_bucket.bkt.arn, "${aws_s3_bucket.bkt.arn}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "bkt" {
+  bucket = aws_s3_bucket.bkt.id
+  policy = data.aws_iam_policy_document.bkt_policy.json
+}

--- a/modules/bucket/variables.tf
+++ b/modules/bucket/variables.tf
@@ -1,3 +1,9 @@
 variable "bucket_name" {
   type = string
 }
+
+variable "principal_role" {
+  type = object({
+    arn = string
+  })
+}

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,4 +1,4 @@
-resource "aws_dynamodb_table" "terraform_locks" {
+resource "aws_dynamodb_table" "state_locks" {
   name         = var.table_name
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = var.hash_key
@@ -13,4 +13,31 @@ resource "aws_dynamodb_table" "terraform_locks" {
   # lifecycle {
   #   prevent_destroy = true
   # }
+}
+
+data "aws_iam_policy_document" "state_locks" {
+  statement {
+    sid    = "TerraformStateLockAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.principal_role.arn}"]
+    }
+
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem"
+    ]
+
+    resources = [
+      "${aws_dynamodb_table.state_locks.arn}"
+    ]
+  }
+}
+
+resource "aws_dynamodb_resource_policy" "state_locks" {
+  resource_arn = aws_dynamodb_table.state_locks.arn
+  policy       = data.aws_iam_policy_document.state_locks.json
 }

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -6,3 +6,9 @@ variable "hash_key" {
   type = string
   default = "LockID"
 }
+
+variable "principal_role" {
+  type = object({
+    arn = string
+  })
+}

--- a/modules/role/main.tf
+++ b/modules/role/main.tf
@@ -7,8 +7,9 @@ locals {
 }
 
 # Example policy
-data "aws_iam_policy" "fetched_policy" {
-  name = "IAMFullAccess"
+data "aws_iam_policy" "fetched_policies" {
+  for_each = toset(var.role_policies)
+  name     = each.key
 }
 
 # Describe the trust entity
@@ -36,13 +37,13 @@ data "aws_iam_policy_document" "assume_policy" {
 }
 
 # Config trust entity authenticate conditions
-resource "aws_iam_role" "remote_sts_role" {
+resource "aws_iam_role" "repo_role" {
   name               = "oidc-${var.org_abbr}-${var.repo_name}"
   assume_role_policy = data.aws_iam_policy_document.assume_policy.json
 }
 
 # Assign permission policy to role
 resource "aws_iam_role_policy_attachments_exclusive" "example" {
-  role_name   = aws_iam_role.remote_sts_role.name
-  policy_arns = [data.aws_iam_policy.fetched_policy.arn]
+  role_name   = aws_iam_role.repo_role.name
+  policy_arns = [for policy in data.aws_iam_policy.fetched_policies : policy.arn]
 }

--- a/modules/role/main.tf
+++ b/modules/role/main.tf
@@ -43,7 +43,7 @@ resource "aws_iam_role" "repo_role" {
 }
 
 # Assign permission policy to role
-resource "aws_iam_role_policy_attachments_exclusive" "example" {
+resource "aws_iam_role_policy_attachments_exclusive" "attach_policy" {
   role_name   = aws_iam_role.repo_role.name
   policy_arns = [for policy in data.aws_iam_policy.fetched_policies : policy.arn]
 }

--- a/modules/role/outputs.tf
+++ b/modules/role/outputs.tf
@@ -1,3 +1,3 @@
-output "role" {
-  value = aws_iam_role.remote_sts_role
+output "role_obj" {
+  value = aws_iam_role.repo_role
 }

--- a/modules/role/outputs.tf
+++ b/modules/role/outputs.tf
@@ -1,0 +1,3 @@
+output "role" {
+  value = aws_iam_role.remote_sts_role
+}

--- a/modules/role/variables.tf
+++ b/modules/role/variables.tf
@@ -5,6 +5,10 @@ variable "oidc" {
   })
 }
 
+variable "role_policies" {
+  type = list(string)
+}
+
 variable "audience_url" {
   type    = string
   default = "sts.amazonaws.com"

--- a/variables.tf
+++ b/variables.tf
@@ -9,13 +9,20 @@ variable "orgnisation" {
 }
 
 variable "org_abbr" {
-  type = string
+  type    = string
   default = "inff"
 }
 
 variable "repos" {
   type    = list(string)
   default = ["access-control"]
+}
+
+variable "repo_permission" {
+  type = map(list(string))
+  default = {
+    "access-control" = ["IAMFullAccess"]
+  }
 }
 
 variable "oidc_provider_url" {


### PR DESCRIPTION
# Summary
Attached bucket policy and DynamoDB resource based policy to allow access from specific repo.
## Details
- Bucket for state file / workflow artifact
  - s3:ListBucket
  - s3:GetObject
  - s3:PutObject
- DynamoDB for state lock
  - dynamodb:GetItem
  - dynamodb:PutItem
  - dynamodb:DeleteItem

## Testing
I have tested the pipeline locally using [act](https://nektosact.com/), with secrets managed in local files.

- **Terraform init** ✔
- **AWS authentication** ✔
- **Terrafrom plan** ✔
  - New Policies appeared in the plan
- **Access tested with dummy role**