### PR TITLE
UpdateBucket - Make prefix lowercase

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,8 @@ module "repo_roles" {
 resource "random_password" "prefix" {
   length  = 5
   special = false
+  lower   = true
+  upper   = false
 }
 
 # Workflow Artifact


### PR DESCRIPTION
# Summary
S3 bucket name accept lowercase only, this will make the prefix to lowercase to comply with the convention.

# Related
#2 