### PR TITLE
feat: add frontend infrastructure policies for S3, CloudFront, and Ro…

### DIFF
--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -69,3 +69,4 @@ variable "oidc_provider_thumbprint" {
   type        = string
   description = "The thumbprint of the OIDC provider"
 }
+

--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -31,6 +31,7 @@ variable "repos" {
   type = list(string)
   default = [
     # "access-control"
+    "frontend-infrastructure"
   ]
 }
 
@@ -43,6 +44,13 @@ variable "repo_permission" {
     #   "AWSSSOMemberAccountAdministrator",                 # For SSO management
     #   "SAMLProviderManagementPolicy"
     # ]
+
+    "frontend-infrastructure" = [
+      "FrontendS3Policy",
+      "FrontendBucketConfigPolicy",
+      "FrontendCloudFrontPolicy",
+      "FrontendRoute53AcmPolicy"
+    ]
   }
 }
 

--- a/modules/policy/main.tf
+++ b/modules/policy/main.tf
@@ -7,28 +7,141 @@ terraform {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 locals {
   # Transform the input policy ARNs into the required format
   custom_policy_arns = {
-    # CustomPolicy = aws_iam_policy.custom_policy.arn
+    FrontendS3Policy               = aws_iam_policy.s3_custom_policy.arn
+    FrontendBucketConfigPolicy    = aws_iam_policy.bucket_config_policy.arn
+    FrontendCloudFrontPolicy      = aws_iam_policy.cloudfront_custom_policy.arn
+    FrontendRoute53AcmPolicy      = aws_iam_policy.route53_acm_policy.arn
   }
-
 }
 
-# Your common Custom Policies
+# 1. S3 Bucket Policy
+resource "aws_iam_policy" "s3_custom_policy" {
+  name        = "FrontendS3BucketPolicy"
+  description = "Policy for managing frontend S3 bucket"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:CreateBucket",
+          "s3:DeleteBucket",
+          "s3:ListBucket",
+          "s3:GetBucketLocation",
+          "s3:GetBucketPolicy",
+          "s3:PutBucketPolicy"
+        ]
+        Resource = "arn:aws:s3:::${var.frontend_bucket_name}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:ListBucketMultipartUploads",
+          "s3:ListMultipartUploadParts"
+        ]
+        Resource = "arn:aws:s3:::${var.frontend_bucket_name}/*"
+      }
+    ]
+  })
+}
 
-# resource "aws_iam_policy" "custom_policy" {
-#   name        = "CustomPolicy"
-#   description = "Custom policy description"
-#   policy = jsonencode({
-#     Version = "2012-10-17"
-#     Statement = [
-#       {
-#         Effect   = "Allow"
-#         Action   = []
-#         Resource = "arn:aws:..."
-#       },
-#       { ... }
-#     ]
-#   })
-# }
+# 2. Bucket Configuration Policy
+resource "aws_iam_policy" "bucket_config_policy" {
+  name        = "FrontendBucketConfigPolicy"
+  description = "Policy for managing frontend bucket configurations"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutBucketVersioning",
+          "s3:GetBucketVersioning",
+          "s3:PutBucketCORS",
+          "s3:GetBucketCORS",
+          "s3:PutBucketPublicAccessBlock",
+          "s3:GetBucketPublicAccessBlock",
+          "s3:PutEncryptionConfiguration",
+          "s3:GetEncryptionConfiguration"
+        ]
+        Resource = "arn:aws:s3:::${var.frontend_bucket_name}"
+      }
+    ]
+  })
+}
+
+# 3. CloudFront Policy
+resource "aws_iam_policy" "cloudfront_custom_policy" {
+  name        = "FrontendCloudFrontPolicy"
+  description = "Policy for managing frontend CloudFront distribution"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateDistribution",
+          "cloudfront:DeleteDistribution",
+          "cloudfront:GetDistribution",
+          "cloudfront:UpdateDistribution",
+          "cloudfront:TagResource",
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation"
+        ]
+        Resource = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateOriginAccessIdentity",
+          "cloudfront:DeleteOriginAccessIdentity",
+          "cloudfront:GetOriginAccessIdentity"
+        ]
+        Resource = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:origin-access-identity/*"
+      }
+    ]
+  })
+}
+
+# 4. Route53 & ACM Policy
+resource "aws_iam_policy" "route53_acm_policy" {
+  name        = "FrontendRoute53AcmPolicy"
+  description = "Policy for managing frontend DNS and certificates"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "route53:ChangeResourceRecordSets",
+          "route53:GetChange",
+          "route53:GetHostedZone",
+          "route53:ListResourceRecordSets"
+        ]
+        Resource = [
+          "arn:aws:route53:::hostedzone/${var.hosted_zone_id}",
+          "arn:aws:route53:::change/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "acm:RequestCertificate",
+          "acm:DescribeCertificate",
+          "acm:DeleteCertificate",
+          "acm:ListCertificates",
+          "acm:AddTagsToCertificate"
+        ]
+        Resource = "arn:aws:acm:*:${data.aws_caller_identity.current.account_id}:certificate/*"
+      }
+    ]
+  })
+}

--- a/modules/policy/main.tf
+++ b/modules/policy/main.tf
@@ -12,10 +12,10 @@ data "aws_caller_identity" "current" {}
 locals {
   # Transform the input policy ARNs into the required format
   custom_policy_arns = {
-    FrontendS3Policy               = aws_iam_policy.s3_custom_policy.arn
-    FrontendBucketConfigPolicy    = aws_iam_policy.bucket_config_policy.arn
-    FrontendCloudFrontPolicy      = aws_iam_policy.cloudfront_custom_policy.arn
-    FrontendRoute53AcmPolicy      = aws_iam_policy.route53_acm_policy.arn
+    FrontendS3Policy           = aws_iam_policy.s3_custom_policy.arn
+    FrontendBucketConfigPolicy = aws_iam_policy.bucket_config_policy.arn
+    FrontendCloudFrontPolicy   = aws_iam_policy.cloudfront_custom_policy.arn
+    FrontendRoute53AcmPolicy   = aws_iam_policy.route53_acm_policy.arn
   }
 }
 
@@ -36,7 +36,6 @@ resource "aws_iam_policy" "s3_custom_policy" {
           "s3:GetBucketPolicy",
           "s3:PutBucketPolicy"
         ]
-        Resource = "arn:aws:s3:::${var.frontend_bucket_name}"
       },
       {
         Effect = "Allow"
@@ -47,7 +46,6 @@ resource "aws_iam_policy" "s3_custom_policy" {
           "s3:ListBucketMultipartUploads",
           "s3:ListMultipartUploadParts"
         ]
-        Resource = "arn:aws:s3:::${var.frontend_bucket_name}/*"
       }
     ]
   })
@@ -72,7 +70,6 @@ resource "aws_iam_policy" "bucket_config_policy" {
           "s3:PutEncryptionConfiguration",
           "s3:GetEncryptionConfiguration"
         ]
-        Resource = "arn:aws:s3:::${var.frontend_bucket_name}"
       }
     ]
   })
@@ -96,7 +93,6 @@ resource "aws_iam_policy" "cloudfront_custom_policy" {
           "cloudfront:CreateInvalidation",
           "cloudfront:GetInvalidation"
         ]
-        Resource = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:distribution/*"
       },
       {
         Effect = "Allow"
@@ -105,7 +101,6 @@ resource "aws_iam_policy" "cloudfront_custom_policy" {
           "cloudfront:DeleteOriginAccessIdentity",
           "cloudfront:GetOriginAccessIdentity"
         ]
-        Resource = "arn:aws:cloudfront::${data.aws_caller_identity.current.account_id}:origin-access-identity/*"
       }
     ]
   })
@@ -126,10 +121,7 @@ resource "aws_iam_policy" "route53_acm_policy" {
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets"
         ]
-        Resource = [
-          "arn:aws:route53:::hostedzone/${var.hosted_zone_id}",
-          "arn:aws:route53:::change/*"
-        ]
+
       },
       {
         Effect = "Allow"
@@ -140,7 +132,6 @@ resource "aws_iam_policy" "route53_acm_policy" {
           "acm:ListCertificates",
           "acm:AddTagsToCertificate"
         ]
-        Resource = "arn:aws:acm:*:${data.aws_caller_identity.current.account_id}:certificate/*"
       }
     ]
   })

--- a/modules/policy/variables.tf
+++ b/modules/policy/variables.tf
@@ -3,12 +3,3 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
-variable "frontend_bucket_name" {
-  description = "Name of the frontend S3 bucket"
-  type        = string
-}
-
-variable "hosted_zone_id" {
-  description = "Route53 hosted zone ID"
-  type        = string
-}

--- a/modules/policy/variables.tf
+++ b/modules/policy/variables.tf
@@ -3,3 +3,12 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+variable "frontend_bucket_name" {
+  description = "Name of the frontend S3 bucket"
+  type        = string
+}
+
+variable "hosted_zone_id" {
+  description = "Route53 hosted zone ID"
+  type        = string
+}


### PR DESCRIPTION
# Description
This PR introduces four new IAM policies specifically designed for managing frontend infrastructure components through Terraform:

## Frontend S3 Bucket Policy
- Manages core S3 bucket operations
- Controls object-level access and operations
- Scoped to the specified frontend bucket


## Frontend Bucket Configuration Policy
- Handles bucket-specific configurations
- Manages versioning, CORS, encryption settings
- Focused on bucket-level settings


## Frontend CloudFront Policy
- Controls CloudFront distribution management
- Handles CDN invalidations and configurations
- Includes Origin Access Identity management


## Frontend Route53 & ACM Policy

- Manages DNS records in the specified hosted zone
- Handles SSL/TLS certificate lifecycle
- Controls ACM certificate operations



# Technical Details

- Each policy follows least privilege principle
- Resources are strictly scoped to frontend infrastructure
- Uses dynamic resource ARNs based on account ID and resource names
- Integrated with existing policy module structure