### PR TITLE
feat(policy): add ECR power user policy

### DIFF
--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -47,6 +47,7 @@ variable "repo_permission" {
     "server-infrastructure" = [
       "NetworkPowerUserPolicy",
       "CloudMapPowerUserPolicy",
+      "ECRPowerUserPolicy"
     ]
   }
 }

--- a/modules/policy/cloud_map.tf
+++ b/modules/policy/cloud_map.tf
@@ -7,6 +7,8 @@ data "aws_iam_policy_document" "cloud_map_poweruser" {
       "servicediscovery:GetNamespace",
       "servicediscovery:ListNamespaces",
       "servicediscovery:TagResource",
+      "servicediscovery:UntagResource",
+      "servicediscovery:ListTagsForResource",
       "servicediscovery:GetOperation",
       "route53:CreateHostedZone",
       "route53:DeleteHostedZone",

--- a/modules/policy/ecr.tf
+++ b/modules/policy/ecr.tf
@@ -1,0 +1,27 @@
+data "aws_iam_policy_document" "ecr_poweruser" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:CreateRepository",
+      "ecr:DeleteRepository",
+      "ecr:DescribeRepositories",
+      "ecr:ListRepositories",
+      "ecr:TagResource",
+      "ecr:PutImageTagMutability",
+      "ecr:PutImageScanningConfiguration",
+      "ecr:GetRepositoryPolicy",
+      "ecr:SetRepositoryPolicy",
+      "ecr:DeleteRepositoryPolicy",
+      "ecr:GetLifecyclePolicy",
+      "ecr:PutLifecyclePolicy",
+      "ecr:DeleteLifecyclePolicy"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ecr_poweruser_policy" {
+  name        = "ECRPowerUserPolicy"
+  description = "Custom policy for managing ECR repositories"
+  policy      = data.aws_iam_policy_document.ecr_poweruser.json
+}

--- a/modules/policy/main.tf
+++ b/modules/policy/main.tf
@@ -18,6 +18,7 @@ locals {
     FrontendRoute53AcmPolicy   = aws_iam_policy.route53_acm_policy.arn
     NetworkPowerUserPolicy     = aws_iam_policy.network_poweruser_policy.arn
     CloudMapPowerUserPolicy    = aws_iam_policy.cloud_map_poweruser_policy.arn
+    ECRPowerUserPolicy         = aws_iam_policy.ecr_poweruser_policy.arn
   }
 }
 


### PR DESCRIPTION
# ECR Policy Implementation for Infrastructure Management
This PR implements IAM policies for managing Amazon Elastic Container Registry (ECR) resources through our infrastructure-as-code pipeline.

## Key Changes:
- Created new ECR power user policy document with comprehensive repository management permissions
- Added permissions for creating, deleting, and managing ECR repositories
- Implemented policy for repository lifecycle management
- Configured permissions for repository policy management
- Added ECR policy ARN to the custom policy set
- Integrated with existing policy module structure

## Test Method:
- Verified policy document syntax and structure
- Confirmed all necessary ECR permissions are included
- Tested policy attachment to OIDC role
- Validated ECR repository creation through GitHub Actions
- Confirmed proper error resolution for AccessDeniedException
- Verified policy integration with existing IAM structure

Related Ticket
[JIRA Ticket: IF-269](https://dext.atlassian.net/jira/software/c/projects/IF/boards/26?selectedIssue=IF-269)