### PR TITLE
Feature/if 297 add OIDC role management for dev repo

### DIFF
--- a/dev/main_bootstrap.tf
+++ b/dev/main_bootstrap.tf
@@ -61,7 +61,7 @@ module "workflow_temp" {
 
 # Terraform states
 module "terraform_state" {
-  for_each       = toset(var.repos)
+  for_each       = toset(var.tf_repos)
   source         = "../modules/bucket"
   bucket_name    = "${var.org_abbr}-${each.key}-tfstate-${random_password.bucket_suffix.result}"
   principal_role = module.repo_roles[each.key].role_obj
@@ -69,7 +69,7 @@ module "terraform_state" {
 
 # Terraform LockIDs
 module "terraform_locks" {
-  for_each       = toset(var.repos)
+  for_each       = toset(var.tf_repos)
   source         = "../modules/db"
   table_name     = "${var.org_abbr}-${each.key}-tflock"
   principal_role = module.repo_roles[each.key].role_obj

--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -52,7 +52,7 @@ variable "repo_permission" {
       "FrontendS3Policy",
       "FrontendBucketConfigPolicy",
       "FrontendCloudFrontPolicy",
-      "FrontendRoute53AcmPolicy"
+      "FrontendRoute53AcmPolicy",
     ],
     "server-infrastructure" = [
       "NetworkPowerUserPolicy",

--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -31,7 +31,17 @@ variable "repos" {
   type = list(string)
   default = [
     "frontend-infrastructure",
-    "server-infrastructure"
+    "server-infrastructure",
+    "frontend",
+    "server",
+  ]
+}
+
+variable "tf_repos" {
+  type = list(string)
+  default = [
+    "frontend-infrastructure",
+    "server-infrastructure",
   ]
 }
 
@@ -47,8 +57,12 @@ variable "repo_permission" {
     "server-infrastructure" = [
       "NetworkPowerUserPolicy",
       "CloudMapPowerUserPolicy",
-      "ECRPowerUserPolicy"
-    ]
+      "ECRPowerUserPolicy",
+    ],
+    "frontend" = [
+    ],
+    "server" = [
+    ],
   }
 }
 
@@ -67,4 +81,3 @@ variable "oidc_provider_thumbprint" {
   type        = string
   description = "The thumbprint of the OIDC provider"
 }
-


### PR DESCRIPTION
## Summary
Little refactor on oidc role (pipeline permission) management to include developer's repo
## Details
### Add oidc role management for dev repo
- frontend
- server

### Seperate terraform repos and ordinary repos
**repos**
  - representing all repos
  - used for permission control and other common resources

**tf_repos**
  - represneting terraform repos
  - used for tf backend management
