### PR TITLE
hotfix: add agw admin policy to server infra pipeline

### DIFF
--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -61,6 +61,7 @@ variable "repo_permission" {
       "LogGroupInFFUserPolicy",
       "ManageECSRolePolicy",
       "ECSPowerUserPolicy",
+      "AmazonAPIGatewayAdministrator",
     ],
     "frontend" = [
       "DevFrontendS3Policy",

--- a/modules/policy/cloud_map.tf
+++ b/modules/policy/cloud_map.tf
@@ -14,6 +14,7 @@ data "aws_iam_policy_document" "cloud_map_poweruser" {
       "servicediscovery:DeleteService",
       "servicediscovery:GetService",
       "servicediscovery:CreateService",
+      "servicediscovery:UpdateService",
       "route53:CreateHostedZone",
       "route53:DeleteHostedZone",
       "route53:GetHostedZone",


### PR DESCRIPTION
## Summary
AGW Administration Policy attachement and minor fix for server infra pipeline
## Details
### AGW
Attach AWS managed policy `AmazonAPIGatewayAdministrator`
### Cloud Map
Add action `servicediscovery:UpdateService`