### PR TITLE
chore: rename sso env from Production to Main

### DIFF
--- a/main/providers.tf
+++ b/main/providers.tf
@@ -56,7 +56,7 @@ provider "aws" {
 # }
 
 locals {
-  sso_env            = "Production"
+  sso_env            = "Main"
   prod_env           = "Production"
   uat_env            = "UAT"
   uat_bootstrap_role = "arn:aws:iam::${var.uat_account_id}:role/${var.bootstrap_role}"


### PR DESCRIPTION
## Summary
Change sso_env setting in main terraform bootstrap folder, from `Production` to `Main`
## Details
This is due to the fact that in access-control repository, terraform under main folder is covering the entire sso management for the under the production aws organisation, including production account and uat account.
The name `Main` for this deployment environment makes more sense as there is another environment managing the dev aws organisation for dev account segregation is called `Development`. 