### PR TITLE
fix: add S3 bucket tagging permission to FrontendS3Policy

### DIFF
--- a/modules/policy/main.tf
+++ b/modules/policy/main.tf
@@ -49,7 +49,8 @@ resource "aws_iam_policy" "s3_custom_policy" {
           "s3:GetLifecycleConfiguration",
           "s3:GetReplicationConfiguration",
           "s3:GetBucketObjectLockConfiguration",
-          "s3:GetBucketTagging"
+          "s3:GetBucketTagging",
+          "s3:PutBucketTagging"
         ]
         Resource = "arn:aws:s3:::*"
       },


### PR DESCRIPTION
- Add s3:PutBucketTagging permission to the general S3 bucket policy
- Fix AccessDenied error when setting tags on S3 buckets
- Align permissions with existing policy definitions in policy_doc.tf